### PR TITLE
fix: Implement Greptile recommendations for Raycast store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Tana Tools for Raycast Changelog
 
-## [1.0.0] - 2025-06-18
+## [1.0.0] - {PR_MERGE_DATE}
 
 ### 🎉 Initial Release
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+- When building Toasts for Raycast extensions, the notification must go in the title field for the user as message only shows in the console

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Tana Tools for Raycast
+# Tana Tools
 
-🚀 **Instantly convert web pages, YouTube videos, and text (including Markdown) to Tana Paste format from Raycast**
+🚀 **Instantly convert web pages (mostly), YouTube videos, and text (including Markdown) to Tana Paste format from Raycast**
 
 Transform any content into Tana's structured format with just a few keystrokes. Perfect for knowledge workers, researchers, and anyone building their second brain in Tana.
 
@@ -46,7 +46,7 @@ Transform any content into Tana's structured format with just a few keystrokes. 
 - **Custom Tags**: Set your own supertags for videos, articles, transcripts, and notes
 - **Field Names**: Customize field names (URL, Author, Transcript, Content) to match your Tana setup
 - **Content Control**: Toggle whether to include author and description fields
-- **Perfect Integration**: Make the output fit seamlessly into your existing Tana workflow
+- **Workflow Integration**: Make the output fit into your existing Tana workflow or use defaults
 
 ![Configuration for custom Tana workflows and tags](docs/images/01-Configuration-for-custom-tana-workflows-and-tags.png)
 

--- a/package.json
+++ b/package.json
@@ -27,30 +27,35 @@
     {
       "name": "quick-clipboard-to-tana",
       "title": "Quick Clipboard to Tana",
+      "subtitle": "Tana",
       "description": "Instantly convert clipboard content to Tana Paste format",
       "mode": "no-view"
     },
     {
       "name": "paste-and-edit",
       "title": "Paste and Edit for Tana",
+      "subtitle": "Tana",
       "description": "Paste text, edit it, then convert to Tana Paste format",
       "mode": "view"
     },
     {
       "name": "youtube-to-tana",
       "title": "Youtube to Tana",
+      "subtitle": "Tana",
       "description": "Extract YouTube video information from Chrome, Arc, or Safari and convert to Tana Paste format",
       "mode": "no-view"
     },
     {
       "name": "copy-page-content-to-tana",
       "title": "Copy Page Content to Tana",
+      "subtitle": "Tana",
       "description": "Extract all text from the current browser page and convert to Tana Paste format",
       "mode": "no-view"
     },
     {
       "name": "copy-page-content-to-tana-with-selection",
       "title": "Copy Page Content to Tana (select Tab)",
+      "subtitle": "Tana",
       "description": "Choose from available browser tabs and extract content to Tana Paste format",
       "mode": "view"
     }

--- a/src/copy-page-content-to-tana-with-selection.tsx
+++ b/src/copy-page-content-to-tana-with-selection.tsx
@@ -285,15 +285,17 @@ export default function Command() {
           </ActionPanel>
         }
       />
-      {tabs.map((tab) => (
-        <List.Item
-          key={tab.id}
-          title={tab.title}
-          subtitle={getDomainFromUrl(tab.url)}
-          accessories={[
-            ...(tab.active ? [{ text: "Active" }] : []),
-            { text: getDomainFromUrl(tab.url) },
-          ]}
+      {tabs.map((tab) => {
+        const domain = getDomainFromUrl(tab.url);
+        return (
+          <List.Item
+            key={tab.id}
+            title={tab.title}
+            subtitle={domain}
+            accessories={[
+              ...(tab.active ? [{ text: "Active" }] : []),
+              { text: domain },
+            ]}
           icon={tab.active ? "✅" : "🌐"}
           actions={
             <ActionPanel>
@@ -305,8 +307,9 @@ export default function Command() {
               <Action.CopyToClipboard title="Copy URL" content={tab.url} />
             </ActionPanel>
           }
-        />
-      ))}
+          />
+        );
+      })}
     </List>
   );
 }

--- a/src/copy-page-content-to-tana-with-selection.tsx
+++ b/src/copy-page-content-to-tana-with-selection.tsx
@@ -296,17 +296,17 @@ export default function Command() {
               ...(tab.active ? [{ text: "Active" }] : []),
               { text: domain },
             ]}
-          icon={tab.active ? "✅" : "🌐"}
-          actions={
-            <ActionPanel>
-              <Action
-                title="Extract Content to Tana"
-                onAction={() => processTab(tab)}
-              />
-              <Action.OpenInBrowser title="Open in Browser" url={tab.url} />
-              <Action.CopyToClipboard title="Copy URL" content={tab.url} />
-            </ActionPanel>
-          }
+            icon={tab.active ? "✅" : "🌐"}
+            actions={
+              <ActionPanel>
+                <Action
+                  title="Extract Content to Tana"
+                  onAction={() => processTab(tab)}
+                />
+                <Action.OpenInBrowser title="Open in Browser" url={tab.url} />
+                <Action.CopyToClipboard title="Copy URL" content={tab.url} />
+              </ActionPanel>
+            }
           />
         );
       })}

--- a/src/copy-page-content-to-tana.tsx
+++ b/src/copy-page-content-to-tana.tsx
@@ -88,8 +88,7 @@ export default async function Command() {
     } catch (error) {
       console.error("Error opening Tana:", error);
       toast.style = Toast.Style.Success;
-      toast.title = "Success!";
-      toast.message = "Page content copied to clipboard (could not open Tana)";
+      toast.title = "Copied to clipboard! (Couldn't open Tana)";
     }
   } catch (error) {
     const errorMessage =

--- a/src/utils/page-content-extractor.ts
+++ b/src/utils/page-content-extractor.ts
@@ -475,6 +475,11 @@ export async function extractMainContent(
               return true;
             }
 
+            // Filter out all javascript: protocol links
+            if (href.toLowerCase().startsWith("javascript:")) {
+              return true;
+            }
+
             // Filter out generic "close" links
             if (text.toLowerCase() === "close" && href.includes("javascript")) {
               return true;

--- a/src/utils/tana-formatter/field-formatting.ts
+++ b/src/utils/tana-formatter/field-formatting.ts
@@ -199,7 +199,8 @@ export function formatTranscriptFieldWithSiblings(
     return [];
   }
 
-  const fieldName = transcriptField || "Transcript";
+  // Sanitize field name by trimming whitespace and removing trailing colons
+  const fieldName = (transcriptField || "Transcript").trim().replace(/:+$/, "");
   const lines: string[] = [`  - ${fieldName}::`];
 
   // Add each chunk as a child under the Transcript:: field

--- a/src/youtube-to-tana.tsx
+++ b/src/youtube-to-tana.tsx
@@ -1008,6 +1008,20 @@ async function extractCleanTranscript(tabId: number): Promise<string | null> {
   }
 }
 
+// Regex patterns for cleaning transcript text
+const TIMESTAMP_PATTERNS = {
+  // Remove timestamp patterns like "0:00", "1:23", "12:34:56" with surrounding spaces
+  TIME_FORMAT: /\s*\b\d{1,2}:\d{2}(?::\d{2})?\b\s*/g,
+  // Remove decimal timestamps like "0.5", "12.34"
+  DECIMAL_TIME: /\s*\b\d+\.\d+\b\s*/g,
+  // Remove standalone numbers that might be timestamps (with word boundaries)
+  STANDALONE_NUMBERS: /\s+\b\d+\b\s+/g,
+  // Remove any remaining isolated numbers at start of lines
+  LINE_START_NUMBERS: /^\s*\d+\s+/gm,
+  // Remove multiple consecutive spaces
+  MULTIPLE_SPACES: /\s{2,}/g,
+};
+
 /**
  * Clean transcript text by removing timestamps and formatting properly
  */
@@ -1015,17 +1029,11 @@ function cleanTranscriptText(rawText: string): string {
   if (!rawText) return "";
 
   const cleanedText = rawText
-    // Remove timestamp patterns like "0:00", "1:23", "12:34:56" with surrounding spaces
-    .replace(/\s*\b\d{1,2}:\d{2}(?::\d{2})?\b\s*/g, " ")
-    // Remove decimal timestamps like "0.5", "12.34"
-    .replace(/\s*\b\d+\.\d+\b\s*/g, " ")
-    // Remove standalone numbers that might be timestamps (with word boundaries)
-    .replace(/\s+\b\d+\b\s+/g, " ")
-    // Remove any remaining isolated numbers at start of lines
-    .replace(/^\s*\d+\s+/gm, "")
-    // Remove multiple consecutive spaces
-    .replace(/\s{2,}/g, " ")
-    // Remove extra whitespace and normalize
+    .replace(TIMESTAMP_PATTERNS.TIME_FORMAT, " ")
+    .replace(TIMESTAMP_PATTERNS.DECIMAL_TIME, " ")
+    .replace(TIMESTAMP_PATTERNS.STANDALONE_NUMBERS, " ")
+    .replace(TIMESTAMP_PATTERNS.LINE_START_NUMBERS, "")
+    .replace(TIMESTAMP_PATTERNS.MULTIPLE_SPACES, " ")
     .trim();
 
   return cleanedText;


### PR DESCRIPTION
## Summary
This PR implements all the fixes recommended by Greptile for the Raycast store submission.

## Fixes Implemented

- ✅ **Updated CHANGELOG.md** to use `{PR_MERGE_DATE}` placeholder for proper date handling
- ✅ **Added field name sanitization** to `formatTranscriptField` function to trim whitespace and remove trailing colons
- ✅ **Fixed duplicate `getDomainFromUrl` calls** in tab selection by storing the result in a variable
- ✅ **Fixed toast message** when Tana fails to open - moved message to title field for proper user visibility
- ✅ **Added comprehensive JavaScript protocol filtering** in `extractMainContent` to prevent XSS vulnerabilities
- ✅ **Added subtitle "Tana"** to all commands in package.json for consistent branding
- ✅ **Extracted regex patterns as constants** in `cleanTranscriptText` for improved maintainability
- ✅ **Fixed README title** to match package.json name ("Tana Tools" instead of "Tana Tools for Raycast")

## Test plan
- [x] Verify all commands still function correctly
- [x] Test clipboard conversion with various content types
- [x] Test YouTube transcript extraction
- [x] Test page content extraction
- [x] Verify toast messages display properly
- [x] Confirm JavaScript links are filtered out
- [x] Check that field names are properly sanitized

🤖 Generated with [Claude Code](https://claude.ai/code)