### PR TITLE
feat: Add videoID field to YouTube command

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,6 +134,15 @@
       "placeholder": "Content"
     },
     {
+      "name": "videoIdField",
+      "type": "textfield",
+      "required": false,
+      "title": "Video ID Field Name",
+      "description": "Field name for YouTube video ID",
+      "default": "videoID",
+      "placeholder": "videoID"
+    },
+    {
       "name": "includeAuthor",
       "type": "checkbox",
       "required": false,

--- a/src/utils/tana-formatter/field-formatting.ts
+++ b/src/utils/tana-formatter/field-formatting.ts
@@ -24,8 +24,10 @@ export function formatMetadataFields(options: {
   description?: string;
   author?: string;
   duration?: string;
+  videoId?: string;
   urlField?: string;
   authorField?: string;
+  videoIdField?: string;
   includeAuthor?: boolean;
   includeDescription?: boolean;
 }): string[] {
@@ -51,6 +53,14 @@ export function formatMetadataFields(options: {
 
   if (options.duration) {
     fields.push(`  - Duration::${options.duration}`);
+  }
+
+  if (options.videoId) {
+    // Sanitize field name by trimming whitespace and removing trailing colons
+    const videoIdFieldName = (options.videoIdField || "videoID")
+      .trim()
+      .replace(/:+$/, "");
+    fields.push(`  - ${videoIdFieldName}::${options.videoId}`);
   }
 
   if (options.description && options.includeDescription !== false) {

--- a/src/utils/tana-formatter/index.ts
+++ b/src/utils/tana-formatter/index.ts
@@ -37,6 +37,7 @@ export interface TanaFormatOptions {
   content?: string;
   lines?: string[];
   duration?: string;
+  videoId?: string;
   useSwipeTag?: boolean;
   transcriptAsFields?: boolean; // Whether to format transcripts as fields vs sibling nodes
   // User preference values
@@ -48,6 +49,7 @@ export interface TanaFormatOptions {
   authorField?: string;
   transcriptField?: string;
   contentField?: string;
+  videoIdField?: string;
   includeAuthor?: boolean;
   includeDescription?: boolean;
 }
@@ -157,9 +159,11 @@ function formatYouTubeVideoContent(options: TanaFormatOptions): string {
         channelUrl: options.channelUrl,
         author: options.author,
         duration: options.duration,
+        videoId: options.videoId,
         description: options.description,
         urlField: options.urlField,
         authorField: options.authorField,
+        videoIdField: options.videoIdField,
         includeAuthor: options.includeAuthor,
         includeDescription: options.includeDescription,
       }),

--- a/src/youtube-to-tana.tsx
+++ b/src/youtube-to-tana.tsx
@@ -899,6 +899,7 @@ export default async function Command() {
           : undefined,
       author: videoInfo.channelName,
       duration: videoInfo.duration,
+      videoId: videoInfo.videoId,
       content: transcriptContent,
       videoTag: preferences.videoTag,
       articleTag: preferences.articleTag,
@@ -907,6 +908,7 @@ export default async function Command() {
       authorField: preferences.authorField,
       transcriptField: preferences.transcriptField,
       contentField: preferences.contentField,
+      videoIdField: preferences.videoIdField,
       includeAuthor: preferences.includeAuthor,
       includeDescription: preferences.includeDescription,
     });


### PR DESCRIPTION
## Summary
- Adds support for extracting and including YouTube video IDs as a Tana field
- Video ID is placed after Duration in the metadata fields
- Configurable field name via preferences (default: "videoID")

## Changes
- Added `videoIdField` preference to package.json
- Updated TanaFormatOptions interface to include videoId and videoIdField
- Modified formatMetadataFields to output the videoID field
- Updated YouTube command to pass videoId to the formatter

## Test plan
- [x] Extract video ID from standard YouTube URLs (youtube.com/watch?v=...)
- [x] Extract video ID from YouTube Shorts URLs (/shorts/...)
- [x] Extract video ID from shortened URLs (youtu.be/...)
- [x] Verify field appears in Tana output after Duration field
- [x] Test with custom videoIdField preference value

Fixes #3

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for including the YouTube video ID in the formatted output.
  * Introduced a customizable preference to set the field name for the YouTube video ID, with a default value of "videoID".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->